### PR TITLE
Remove minLength support for required properties.

### DIFF
--- a/modules/json_schema/src/Normalizer/DataDefinitionNormalizer.php
+++ b/modules/json_schema/src/Normalizer/DataDefinitionNormalizer.php
@@ -127,14 +127,6 @@ class DataDefinitionNormalizer extends NormalizerBase {
 
     }
 
-    if ($data['type'] == 'string') {
-      // @todo confirm minLength is needed for required items.
-      // This enforces that required properties not be empty string values.
-      if ($this->requiredProperty($property)) {
-        $data['minLength'] = 1;
-      }
-    }
-
     if (isset($context['parent']) && $context['parent']->getDataType() == 'field_item:uuid') {
       $data['format'] = 'uuid';
     }


### PR DESCRIPTION
The current behavior of JSON Schema identifies required string properties and sets them to have a minLength of 1. This turns out to be a bit overzealous in setting up validation. When tested with https://github.com/kriszyp/json-schema, this validation would run against a default_value setting an empty string and fail, because the default value is technically violating the rule.
