### PR TITLE
Do not require route for normalizer

### DIFF
--- a/modules/json_schema/json_schema.services.yml
+++ b/modules/json_schema/json_schema.services.yml
@@ -44,6 +44,7 @@ services:
   # This is the main JSON Schema normalizer.
   serializer.normalizer.schema.json_schema:
     class: Drupal\json_schema\Normalizer\SchemataSchemaNormalizer
+    arguments: ['@router.route_provider']
     tags:
       - { name: normalizer, priority: 10 }
 

--- a/modules/json_schema/src/Normalizer/SchemataSchemaNormalizer.php
+++ b/modules/json_schema/src/Normalizer/SchemataSchemaNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\json_schema\Normalizer;
 
-use Drupal\json_schema\Normalizer\NormalizerBase;
+use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\schemata\Schema\SchemaInterface;
 use Drupal\schemata\SchemaUrl;
 use Drupal\Component\Utility\NestedArray;
@@ -20,6 +20,23 @@ class SchemataSchemaNormalizer extends NormalizerBase {
   protected $supportedInterfaceOrClass = 'Drupal\schemata\Schema\SchemaInterface';
 
   /**
+   * The route provider service.
+   *
+   * @var \Drupal\Core\Routing\RouteProviderInterface
+   */
+  protected $routeProvider;
+
+  /**
+   * Constructs the BlockListController.
+   *
+   * @param \Drupal\Core\Routing\RouteProviderInterface $route_provider
+   *   The route provider service.
+   */
+  public function __construct(RouteProviderInterface $route_provider) {
+    $this->routeProvider = $route_provider;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function normalize($entity, $format = NULL, array $context = array()) {
@@ -30,10 +47,8 @@ class SchemataSchemaNormalizer extends NormalizerBase {
       'type' => 'object',
     ];
 
-    /** @var \Drupal\Core\Routing\RouteProvider $route_provider */
-    $route_provider = \Drupal::service('router.route_provider');
     // If REST route is enabled add id.
-    if ($routes = $route_provider->getRoutesByNames([SchemaUrl::getRouteName($format)])) {
+    if ($routes = $this->routeProvider->getRoutesByNames([SchemaUrl::getRouteName($format)])) {
       $normalized['id'] = SchemaUrl::fromSchema($format, $entity)->toString();
     }
     $normalized = array_merge($normalized, $entity->getMetadata());

--- a/modules/json_schema/src/Normalizer/SchemataSchemaNormalizer.php
+++ b/modules/json_schema/src/Normalizer/SchemataSchemaNormalizer.php
@@ -27,9 +27,15 @@ class SchemataSchemaNormalizer extends NormalizerBase {
     /* @var $entity \Drupal\schemata\Schema\SchemaInterface */
     $normalized = [
       '$schema' => 'http://json-schema.org/draft-04/schema#',
-      'id' => SchemaUrl::fromSchema($format, $entity)->toString(),
       'type' => 'object',
     ];
+
+    /** @var \Drupal\Core\Routing\RouteProvider $route_provider */
+    $route_provider = \Drupal::service('router.route_provider');
+    // If REST route is enabled add id.
+    if ($routes = $route_provider->getRoutesByNames([SchemaUrl::getRouteName($format)])) {
+      $normalized['id'] = SchemaUrl::fromSchema($format, $entity)->toString();
+    }
     $normalized = array_merge($normalized, $entity->getMetadata());
 
     // Stash schema request parameters.

--- a/src/SchemaUrl.php
+++ b/src/SchemaUrl.php
@@ -74,9 +74,8 @@ class SchemaUrl {
    *   The route name.
    */
   public static function getRouteName($format, $bundle = '') {
-    $route = empty($bundle) ? 'rest.schemata_entity_base.GET.' . $format
+    return empty($bundle) ? 'rest.schemata_entity_base.GET.' . $format
       : 'rest.schemata_entity_bundle.GET.' . $format;
-    return $route;
   }
 
 }

--- a/src/SchemaUrl.php
+++ b/src/SchemaUrl.php
@@ -45,8 +45,7 @@ class SchemaUrl {
    *   The schema resource Url object.
    */
   public static function fromOptions($format, $entity_type, $bundle = NULL) {
-    $route = empty($bundle) ? 'rest.schemata_entity_base.GET.' . $format
-      : 'rest.schemata_entity_bundle.GET.' . $format;
+    $route = static::getRouteName($format, $bundle);
 
     $parameters = [
       'entity_type' => $entity_type,
@@ -61,6 +60,23 @@ class SchemaUrl {
       ],
       'absolute' => TRUE,
     ]);
+  }
+
+  /**
+   * Determine the route name.
+   *
+   * @param string $format
+   *   The route format.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return string
+   *   The route name.
+   */
+  public static function getRouteName($format, $bundle = '') {
+    $route = empty($bundle) ? 'rest.schemata_entity_base.GET.' . $format
+      : 'rest.schemata_entity_bundle.GET.' . $format;
+    return $route;
   }
 
 }


### PR DESCRIPTION
I would like to use Schemata's \Drupal\json_schema\Normalizer\SchemataSchemaNormalizer in the Drupal Waterwheel module. Currently todo this a site would have to have the Schemata REST resources enabled. I am using the normalizer to create Swagger JSON file.

This patch simply checks to see if the route is enabled before setting 'id' otherwise it will fail without the resource enabled.
