### PR TITLE
Issue #2821228: Stop mapping readonly properties as required in schema.

### DIFF
--- a/modules/json_schema/src/Normalizer/NormalizerBase.php
+++ b/modules/json_schema/src/Normalizer/NormalizerBase.php
@@ -84,7 +84,7 @@ abstract class NormalizerBase extends SerializationNormalizerBase implements Den
    *   purposes.
    */
   protected function requiredProperty(DataDefinitionInterface $property) {
-    return $property->isReadOnly() || $property->isRequired();
+    return $property->isRequired();
   }
 
 }


### PR DESCRIPTION
While readonly is decent to represent as required for read purposes, for use cases around writing to Drupal REST resources it confuses the issue because you do not actually submit those readonly properties.

This reduces the required properties to just those which are explicitly marked as required in Drupal's field system.