### PR TITLE
Issue #2826459: Make type mapping from Drupal to JSON Schema extensible.

### DIFF
--- a/modules/json_schema/json_schema.services.yml
+++ b/modules/json_schema/json_schema.services.yml
@@ -51,3 +51,7 @@ services:
     class: Drupal\json_schema\Encoder\JsonEncoder
     tags:
       - { name: encoder, priority: 10, format: json_schema }
+
+  plugin.manager.json_schema.type_mapper:
+    class: Drupal\json_schema\Plugin\Type\TypeMapperPluginManager
+    arguments: ['@container.namespaces', '@module_handler']

--- a/modules/json_schema/src/Annotation/TypeMapper.php
+++ b/modules/json_schema/src/Annotation/TypeMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\json_schema\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a JSON Schema Type Mapper annotation object.
+ *
+ * Plugin Namespace: Plugin\json_schema\type_mapper
+ *
+ * @ingroup third_party
+ *
+ * @Annotation
+ */
+class TypeMapper extends Plugin {
+
+  /**
+   * The TypeMapper plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+}

--- a/modules/json_schema/src/Normalizer/DataDefinitionNormalizer.php
+++ b/modules/json_schema/src/Normalizer/DataDefinitionNormalizer.php
@@ -79,53 +79,15 @@ class DataDefinitionNormalizer extends NormalizerBase {
    *   Serializer context.
    *
    * @return array
-   *   Discrete values of the property definition
+   *   Discrete values of the property definition.
+   *
+   * @todo identify how to cleanly inject the plugin manager without requiring
+   *   updates to many of the normalizers.
    */
   protected function extractPropertyData(DataDefinitionInterface $property, array $context = []) {
-    $data = [
-      // 'constraints' => print_r($property->getConstraints(), TRUE),
-      // 'settings' => print_r($property->getSettings(), TRUE),
-      // 'class' => get_class($Property),
-      // 'computed' => $property->isComputed(),
-    ];
-
-    if ($item = $property->getLabel()) {
-      $data['title'] = $item;
-    }
-    if ($item = $property->getDescription()) {
-      $data['description'] = $item;
-    }
-
-    $type = $property->getDataType();
-    switch ($type) {
-      case 'email':
-        $data['type'] = 'string';
-        $data['format'] = 'email';
-        break;
-
-      case 'datetime_iso8601':
-        $data['type'] = 'string';
-        $data['format'] = 'date';
-        break;
-
-      case 'timestamp':
-        $data['type'] = 'number';
-        $data['format'] = 'utc-millisec';
-        break;
-
-      case 'filter_format':
-        // @todo machine_name format or regex validation.
-        $data['type'] = 'string';
-        break;
-
-      case 'entity_reference':
-        $data['type'] = 'object';
-        break;
-
-      default:
-        $data['type'] = $type;
-
-    }
+    $type_mapper_manager = \Drupal::service('plugin.manager.json_schema.type_mapper');
+    $data = $type_mapper_manager->createInstance($property->getDataType())
+      ->getMappedValue($property);
 
     if (isset($context['parent']) && $context['parent']->getDataType() == 'field_item:uuid') {
       $data['format'] = 'uuid';

--- a/modules/json_schema/src/Plugin/Type/TypeMapperPluginManager.php
+++ b/modules/json_schema/src/Plugin/Type/TypeMapperPluginManager.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\Type;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Component\Plugin\FallbackPluginManagerInterface;
+/**
+ * Manages TypeMapper plugins.
+ *
+ * TypeMappers are used to adapt Drupal TypedData types to JSON Schema specs.
+ *
+ * @see \Drupal\json_schema\Annotation\TypeMapper
+ * @see \Drupal\json_schema\Plugin\TypeMapperBase
+ * @see \Drupal\json_schema\Plugin\TypeMapperInterface
+ * @see plugin_api
+ */
+class TypeMapperPluginManager extends DefaultPluginManager implements FallbackPluginManagerInterface {
+
+  /**
+   * The TypeMapper to use if there's a miss.
+   *
+   * @param string
+   */
+  const FALLBACK_TYPE_MAPPER = 'fallback';
+
+  /**
+   * Constructs a new \Drupal\rest\Plugin\Type\ResourcePluginManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/json_schema/type_mapper', $namespaces, $module_handler, 'Drupal\json_schema\Plugin\TypeMapperInterface', 'Drupal\json_schema\Annotation\TypeMapper');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFallbackPluginId($plugin_id, array $configuration = array()) {
+    return static::FALLBACK_TYPE_MAPPER;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/TypeMapperBase.php
+++ b/modules/json_schema/src/Plugin/TypeMapperBase.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\json_schema\Plugin;
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for TypeMappers plugins.
+ *
+ * An empty, subclassed plugin will use the default behavior here, including the
+ * use of the plugin ID as the JSON Schema type.
+ *
+ * This is slightly different from the behavior of the fallback plugin, which
+ * uses the data type off the DataDefinition.
+ *
+ * @see \Drupal\json_schema\Plugin\TypeMapperPluginManager
+ * @see \Drupal\json_schema\Plugin\json_schema\type_mapper\FallbackTypeMapper
+ */
+class TypeMapperBase extends PluginBase implements TypeMapperInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = [
+      'type' => $this->getPluginId(),
+    ];
+
+    if ($item = $property->getLabel()) {
+      $value['title'] = $item;
+    }
+    if ($item = $property->getDescription()) {
+      $value['description'] = $item;
+    }
+
+    return $value;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/TypeMapperInterface.php
+++ b/modules/json_schema/src/Plugin/TypeMapperInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\json_schema\Plugin;
+
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * Defines the extended methods needed for a TypeMapper plugin.
+ */
+interface TypeMapperInterface {
+
+  /**
+   * Convert the data definition property to a JSON Schema form.
+   *
+   * @param \Drupal\Core\TypedData\DataDefinitionInterface $property
+   *   The data definition property.
+   *
+   * @return mixed
+   *  The mapped value to represent the property in a JSON Schema schema.
+   */
+  public function getMappedValue(DataDefinitionInterface $property);
+
+}

--- a/modules/json_schema/src/Plugin/json_schema/type_mapper/DateTime8601TypeMapper.php
+++ b/modules/json_schema/src/Plugin/json_schema/type_mapper/DateTime8601TypeMapper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\json_schema\type_mapper;
+
+use Drupal\json_schema\Plugin\TypeMapperBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * Converts Data Definition properties of the datetime_iso8601 to JSON Schema.
+ *
+ * @TypeMapper(
+ *  id = "datetime_iso8601"
+ * )
+ */
+class DateTime8601TypeMapper extends TypeMapperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = parent::getMappedValue($property);
+    $value['type'] = 'string';
+    $value['format'] = 'date';
+    return $value;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/json_schema/type_mapper/EmailTypeMapper.php
+++ b/modules/json_schema/src/Plugin/json_schema/type_mapper/EmailTypeMapper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\json_schema\type_mapper;
+
+use Drupal\json_schema\Plugin\TypeMapperBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * Converts Data Definition properties of the email to JSON Schema.
+ *
+ * @TypeMapper(
+ *  id = "email"
+ * )
+ */
+class EmailTypeMapper extends TypeMapperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = parent::getMappedValue($property);
+    $value['type'] = 'string';
+    $value['format'] = 'email';
+    return $value;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/json_schema/type_mapper/EntityReferenceTypeMapper.php
+++ b/modules/json_schema/src/Plugin/json_schema/type_mapper/EntityReferenceTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\json_schema\type_mapper;
+
+use Drupal\json_schema\Plugin\TypeMapperBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * Converts Data Definition properties of entity_reference type to JSON Schema.
+ *
+ * @TypeMapper(
+ *  id = "entity_reference"
+ * )
+ */
+class EntityReferenceTypeMapper extends TypeMapperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = parent::getMappedValue($property);
+    $value['type'] = 'object';
+    return $value;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/json_schema/type_mapper/FallbackTypeMapper.php
+++ b/modules/json_schema/src/Plugin/json_schema/type_mapper/FallbackTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\json_schema\type_mapper;
+
+use Drupal\json_schema\Plugin\TypeMapperBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * The fallback type mapper, explicitly called if none other is applicable.
+ *
+ * @TypeMapper(
+ *  id = "fallback"
+ * )
+ */
+class FallbackTypeMapper extends TypeMapperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = parent::getMappedValue($property);
+    $value['type'] = $property->getDataType();
+    return $value;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/json_schema/type_mapper/FilterFormatTypeMapper.php
+++ b/modules/json_schema/src/Plugin/json_schema/type_mapper/FilterFormatTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\json_schema\type_mapper;
+
+use Drupal\json_schema\Plugin\TypeMapperBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * Converts Data Definition properties of filter_format type to JSON Schema.
+ *
+ * @TypeMapper(
+ *  id = "filter_format"
+ * )
+ */
+class FilterFormatTypeMapper extends TypeMapperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = parent::getMappedValue($property);
+    $value['type'] = 'string';
+    return $value;
+  }
+
+}

--- a/modules/json_schema/src/Plugin/json_schema/type_mapper/TimestampTypeMapper.php
+++ b/modules/json_schema/src/Plugin/json_schema/type_mapper/TimestampTypeMapper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\json_schema\Plugin\json_schema\type_mapper;
+
+use Drupal\json_schema\Plugin\TypeMapperBase;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+
+/**
+ * Converts Data Definition properties of timestamp type to JSON Schema.
+ *
+ * @TypeMapper(
+ *  id = "timestamp"
+ * )
+ */
+class TimestampTypeMapper extends TypeMapperBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappedValue(DataDefinitionInterface $property) {
+    $value = parent::getMappedValue($property);
+    $value['type'] = 'number';
+    $value['format'] = 'utc-millisec';
+    return $value;
+  }
+
+}


### PR DESCRIPTION
Pretty sizeable change here, but it's working well for me. Here we have a new plugin type that allows defining mappings from DataDefinitions in Drupal's Typed Data API to JSON Schema types.
