### PR TITLE
Replaces service argument rest.link_manager with hal.link_manager for HAL normalizer service

### DIFF
--- a/schemata_json_schema/schemata_json_schema.services.yml
+++ b/schemata_json_schema/schemata_json_schema.services.yml
@@ -82,12 +82,8 @@ services:
   # ----------------------------------------------------------------------------
   # - 3. HAL+JSON format.
   # ----------------------------------------------------------------------------
-  # HAL+JSON version of the Data Reference normalizer.
-  serializer.normalizer.data_reference_definition.schema_json.hal_json:
-    class: Drupal\schemata_json_schema\Normalizer\hal\DataReferenceDefinitionNormalizer
-    arguments: ['@entity_type.manager', '@rest.link_manager']
-    tags:
-      - { name: normalizer, priority: 30 }
+  # Note: The HAL+JSON version of the Data Reference normalizer depends on the
+  # HAL module and is in registered in SchemataHalServiceProvider.
 
   # Normalize complex data properties for HAL.
   # This services is primarily used to short-circuit merging normalization of

--- a/schemata_json_schema/src/SchemataHalServiceProvider.php
+++ b/schemata_json_schema/src/SchemataHalServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\schemata_json_schema;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Provides schemata services that depend directly on HAL.
+ */
+class SchemataHalServiceProvider implements ServiceProviderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    $modules = $container->getParameter(('container.modules'));
+    if (!isset($modules['hal'])) {
+      return;
+    }
+
+    // Provide the HAL+JSON version of the Data Reference normalizer here
+    // because the hal.link_manager service argument requires HAL.
+    $container->register('serializer.normalizer.data_reference_definition.schema_json.hal_json', 'Drupal\schemata_json_schema\Normalizer\hal\DataReferenceDefinitionNormalizer')
+      ->addArgument(new Reference('entity_type.manager'))
+      ->addArgument(new Reference('hal.link_manager'))
+      ->addTag('normalizer', ['priority' => 30]);
+  }
+
+}


### PR DESCRIPTION
Thanks for this awesome module!

It currently doesn't work with Drupal 8.3 because of https://www.drupal.org/node/2830467.

This PR attempts to fix the error without making the module depend on HAL.
