### PR TITLE
Issue #2870904 Add entity type only schema routes for entity types with bundles - reroll

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -82,7 +82,7 @@ class Controller extends ControllerBase {
    * @return \Drupal\Core\Cache\CacheableResponse
    *   The response object.
    */
-  public function serialize($entity_type_id, $bundle, Request $request) {
+  public function serialize($entity_type_id, Request $request, $bundle = NULL) {
     $parts = $this->extractFormatNames($request);
 
     // Load the data to serialize from the route information on the current

--- a/src/Routing/Routes.php
+++ b/src/Routing/Routes.php
@@ -71,29 +71,79 @@ class Routes implements ContainerInjectionInterface {
     // Loop through all the entity types.
     foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
       $entity_type_id = $entity_type->id();
-      $has_bundle = (bool) $entity_type->getBundleEntityType();
-      // Loop through all the bundles for the entity type.
-      $bundles_info = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
-      foreach (array_keys($bundles_info) as $bundle) {
-        $path = $has_bundle ?
-          sprintf('/schemata/%s/%s', $entity_type_id, $bundle) :
-          sprintf('/schemata/%s', $entity_type_id);
-        $route = new Route($path);
-        $route->setRequirement('_permission', 'access schemata data models');
-        $route->setMethods(['GET']);
-        $route->setDefaults([
-          'entity_type_id' => $entity_type_id,
-          'bundle' => $has_bundle ? $bundle : NULL,
-          RouteObjectInterface::CONTROLLER_NAME => static::CONTROLLER,
-        ]);
-        $route_name = $has_bundle ?
-          sprintf('schemata.%s:%s', $entity_type_id, $bundle) :
-          sprintf('schemata.%s', $entity_type_id);
-        $route_collection->add($route_name, $route);
+      // Add a route for all entity types.
+      $route_collection->add($this->createRouteName($entity_type_id), $this->createRoute($entity_type_id));
+
+      // If this entity type has a bundle entity type then add a route for each bundle.
+      if ($entity_type->getBundleEntityType()) {
+        // Loop through all the bundles for the entity type.
+        $bundles_info = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
+        foreach (array_keys($bundles_info) as $bundle) {
+          $route_collection->add($this->createRouteName($entity_type_id, $bundle), $this->createRoute($entity_type_id, $bundle));
+        }
       }
     }
-
     return $route_collection;
+  }
+
+  /**
+   * Creates a route for a entity type and bundle.
+   *
+   * @param string $entity_type_id
+   *   The entity type id.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return \Symfony\Component\Routing\Route
+   *   The route.
+   */
+  protected function createRoute($entity_type_id, $bundle = NULL) {
+    $path = $this->getRoutePath($entity_type_id, $bundle);
+    $route = new Route($path);
+    $route->setRequirement('_permission', 'access schemata data models');
+    $route->setMethods(['GET']);
+    $defaults = [
+      'entity_type_id' => $entity_type_id,
+      RouteObjectInterface::CONTROLLER_NAME => static::CONTROLLER,
+    ];
+    if ($bundle) {
+      $defaults['bundle'] = $bundle;
+    }
+    $route->setDefaults($defaults);
+    return $route;
+  }
+
+  /**
+   * Creates a route name for a entity type and bundle.
+   *
+   * @param string $entity_type_id
+   *   The entity type id.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return string
+   *   The route name.
+   */
+  protected function createRouteName($entity_type_id, $bundle = NULL) {
+    return $bundle ? sprintf('schemata.%s:%s', $entity_type_id, $bundle) : sprintf('schemata.%s', $entity_type_id);
+  }
+
+  /**
+   * Creates a route path for a entity type and bundle.
+   *
+   * @param string $entity_type_id
+   *   The entity type id.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return string
+   *   The route path.
+   */
+  protected function getRoutePath($entity_type_id, $bundle = NULL) {
+    $path = $bundle ?
+      sprintf('/schemata/%s/%s', $entity_type_id, $bundle) :
+      sprintf('/schemata/%s', $entity_type_id);
+    return $path;
   }
 
 }

--- a/tests/expectations/node.api_json.json
+++ b/tests/expectations/node.api_json.json
@@ -1,0 +1,197 @@
+{
+    "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+    "id": "{base_url}\/schemata\/node?_format=schema_json&_describes=api_json",
+    "type": "object",
+    "title": "node Schema",
+    "description": "Describes the payload for 'node' entities.",
+    "properties": {
+        "attributes": {
+            "type": "object",
+            "properties": {
+                "nid": {
+                    "type": "integer",
+                    "title": "ID"
+                },
+                "uuid": {
+                    "type": "string",
+                    "title": "UUID",
+                    "maxLength": 128
+                },
+                "vid": {
+                    "type": "integer",
+                    "title": "Revision ID"
+                },
+                "langcode": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "title": "Language code"
+                        },
+                        "language": {
+                            "type": "language_reference",
+                            "title": "Language object",
+                            "description": "The referenced language"
+                        }
+                    },
+                    "required": [
+                        "value"
+                    ],
+                    "title": "Language"
+                },
+                "revision_timestamp": {
+                    "type": "number",
+                    "title": "Revision create time",
+                    "format": "utc-millisec",
+                    "description": "The time that the current revision was created."
+                },
+                "revision_log": {
+                    "type": "string",
+                    "title": "Revision log message",
+                    "description": "Briefly describe the changes you have made.",
+                    "default": ""
+                },
+                "status": {
+                    "type": "boolean",
+                    "title": "Publishing status",
+                    "description": "A boolean indicating the published state.",
+                    "default": true
+                },
+                "title": {
+                    "type": "string",
+                    "title": "Title",
+                    "maxLength": 255
+                },
+                "created": {
+                    "type": "number",
+                    "title": "Authored on",
+                    "format": "utc-millisec",
+                    "description": "The time that the node was created."
+                },
+                "changed": {
+                    "type": "number",
+                    "title": "Changed",
+                    "format": "utc-millisec",
+                    "description": "The time that the node was last edited."
+                },
+                "promote": {
+                    "type": "boolean",
+                    "title": "Promoted to front page",
+                    "default": true
+                },
+                "sticky": {
+                    "type": "boolean",
+                    "title": "Sticky at top of lists",
+                    "default": false
+                },
+                "revision_translation_affected": {
+                    "type": "boolean",
+                    "title": "Revision translation affected",
+                    "description": "Indicates if the last edit of a translation belongs to current revision."
+                },
+                "default_langcode": {
+                    "type": "boolean",
+                    "title": "Default translation",
+                    "description": "A flag indicating whether this is the default translation.",
+                    "default": true
+                }
+            },
+            "required": [
+                "nid",
+                "uuid",
+                "vid",
+                "title",
+                "revision_translation_affected"
+            ]
+        },
+        "relationships": {
+            "properties": {
+                "type": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "id"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "title": "Referenced resource",
+                                    "enum": [
+                                        "node_type--node_type"
+                                    ]
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "title": "Resource ID",
+                                    "format": "uuid",
+                                    "maxLength": 128
+                                }
+                            }
+                        }
+                    },
+                    "title": "Resource Identifier"
+                },
+                "revision_uid": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "id"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "title": "Referenced resource",
+                                    "enum": [
+                                        "user--user"
+                                    ]
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "title": "Resource ID",
+                                    "format": "uuid",
+                                    "maxLength": 128
+                                }
+                            }
+                        }
+                    },
+                    "title": "Resource Identifier"
+                },
+                "uid": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "id"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "title": "Referenced resource",
+                                    "enum": [
+                                        "user--user"
+                                    ]
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "title": "Resource ID",
+                                    "format": "uuid",
+                                    "maxLength": 128
+                                }
+                            }
+                        }
+                    },
+                    "title": "Resource Identifier"
+                }
+            },
+            "type": "object"
+        }
+    }
+}

--- a/tests/expectations/node.hal_json.json
+++ b/tests/expectations/node.hal_json.json
@@ -1,0 +1,365 @@
+{
+    "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+    "id": "{base_url}\/schemata\/node?_format=schema_json&_describes=hal_json",
+    "type": "object",
+    "title": "node Schema",
+    "description": "Describes the payload for 'node' entities.",
+    "properties": {
+        "nid": {
+            "type": "array",
+            "title": "ID",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "uuid": {
+            "type": "array",
+            "title": "UUID",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 128
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "vid": {
+            "type": "array",
+            "title": "Revision ID",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "langcode": {
+            "type": "array",
+            "title": "Language",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Language code"
+                    },
+                    "language": {
+                        "type": "language_reference",
+                        "title": "Language object",
+                        "description": "The referenced language"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "type": {
+            "type": "object",
+            "title": "Content type",
+            "description": "The referenced entity"
+        },
+        "revision_timestamp": {
+            "type": "array",
+            "title": "Revision create time",
+            "description": "The time that the current revision was created.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "revision_uid": {
+            "type": "object",
+            "title": "User",
+            "description": "The referenced entity"
+        },
+        "revision_log": {
+            "type": "array",
+            "title": "Revision log message",
+            "description": "Briefly describe the changes you have made.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": ""
+                }
+            ],
+            "maxItems": 1
+        },
+        "status": {
+            "type": "array",
+            "title": "Publishing status",
+            "description": "A boolean indicating the published state.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        },
+        "title": {
+            "type": "array",
+            "title": "Title",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "uid": {
+            "type": "object",
+            "title": "User",
+            "description": "The referenced entity"
+        },
+        "created": {
+            "type": "array",
+            "title": "Authored on",
+            "description": "The time that the node was created.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "changed": {
+            "type": "array",
+            "title": "Changed",
+            "description": "The time that the node was last edited.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "promote": {
+            "type": "array",
+            "title": "Promoted to front page",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        },
+        "sticky": {
+            "type": "array",
+            "title": "Sticky at top of lists",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": false
+                }
+            ],
+            "maxItems": 1
+        },
+        "revision_translation_affected": {
+            "type": "array",
+            "title": "Revision translation affected",
+            "description": "Indicates if the last edit of a translation belongs to current revision.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "default_langcode": {
+            "type": "array",
+            "title": "Default translation",
+            "description": "A flag indicating whether this is the default translation.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        },
+        "_links": {
+            "title": "HAL Links",
+            "description": "Object of links with the rels as the keys",
+            "type": "object",
+            "properties": {
+                "self": {
+                    "$ref": "#\/definitions\/linkObject"
+                },
+                "type": {
+                    "$ref": "#\/definitions\/linkObject"
+                }
+            }
+        }
+    },
+    "required": [
+        "nid",
+        "uuid",
+        "vid",
+        "title",
+        "revision_translation_affected"
+    ],
+    "definitions": {
+        "linkArray": {
+            "title": "HAL Link Array",
+            "description": "An array of linkObjects of the same link relation",
+            "type": "array",
+            "items": {
+                "$ref": "#\/definitions\/linkObject"
+            }
+        },
+        "linkObject": {
+            "title": "HAL Link Object",
+            "description": "An object with link information.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "description": "Name of a resource, link, action, etc.",
+                    "type": "string"
+                },
+                "title": {
+                    "title": "Title",
+                    "description": "A title for a resource, link, action, etc.",
+                    "type": "string"
+                },
+                "href": {
+                    "title": "HREF",
+                    "description": "A hyperlink URL.",
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "required": [
+                "href"
+            ]
+        }
+    }
+}

--- a/tests/expectations/node.json.json
+++ b/tests/expectations/node.json.json
@@ -1,0 +1,355 @@
+{
+    "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+    "id": "{base_url}\/schemata\/node?_format=schema_json&_describes=json",
+    "type": "object",
+    "title": "node Schema",
+    "description": "Describes the payload for 'node' entities.",
+    "properties": {
+        "nid": {
+            "type": "array",
+            "title": "ID",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "uuid": {
+            "type": "array",
+            "title": "UUID",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 128
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "vid": {
+            "type": "array",
+            "title": "Revision ID",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "langcode": {
+            "type": "array",
+            "title": "Language",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Language code"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "type": {
+            "type": "array",
+            "title": "Content type",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "target_id": {
+                        "type": "string",
+                        "title": "Content type ID"
+                    }
+                },
+                "required": [
+                    "target_id"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "revision_timestamp": {
+            "type": "array",
+            "title": "Revision create time",
+            "description": "The time that the current revision was created.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "revision_uid": {
+            "type": "array",
+            "title": "Revision user",
+            "description": "The user ID of the author of the current revision.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "target_id": {
+                        "type": "integer",
+                        "title": "User ID"
+                    }
+                },
+                "required": [
+                    "target_id"
+                ],
+                "title": "User",
+                "description": "The referenced entity"
+            },
+            "maxItems": 1
+        },
+        "revision_log": {
+            "type": "array",
+            "title": "Revision log message",
+            "description": "Briefly describe the changes you have made.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": ""
+                }
+            ],
+            "maxItems": 1
+        },
+        "status": {
+            "type": "array",
+            "title": "Publishing status",
+            "description": "A boolean indicating the published state.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        },
+        "title": {
+            "type": "array",
+            "title": "Title",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "uid": {
+            "type": "array",
+            "title": "Authored by",
+            "description": "The username of the content author.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "target_id": {
+                        "type": "integer",
+                        "title": "User ID"
+                    }
+                },
+                "required": [
+                    "target_id"
+                ],
+                "title": "User",
+                "description": "The referenced entity"
+            },
+            "maxItems": 1
+        },
+        "created": {
+            "type": "array",
+            "title": "Authored on",
+            "description": "The time that the node was created.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "changed": {
+            "type": "array",
+            "title": "Changed",
+            "description": "The time that the node was last edited.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "promote": {
+            "type": "array",
+            "title": "Promoted to front page",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        },
+        "sticky": {
+            "type": "array",
+            "title": "Sticky at top of lists",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": false
+                }
+            ],
+            "maxItems": 1
+        },
+        "revision_translation_affected": {
+            "type": "array",
+            "title": "Revision translation affected",
+            "description": "Indicates if the last edit of a translation belongs to current revision.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "default_langcode": {
+            "type": "array",
+            "title": "Default translation",
+            "description": "A flag indicating whether this is the default translation.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        }
+    },
+    "required": [
+        "nid",
+        "uuid",
+        "vid",
+        "type",
+        "title",
+        "revision_translation_affected"
+    ]
+}

--- a/tests/expectations/taxonomy_term.api_json.json
+++ b/tests/expectations/taxonomy_term.api_json.json
@@ -1,0 +1,153 @@
+{
+    "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+    "id": "{base_url}\/schemata\/taxonomy_term?_format=schema_json&_describes=api_json",
+    "type": "object",
+    "title": "taxonomy_term Schema",
+    "description": "Describes the payload for 'taxonomy_term' entities.",
+    "properties": {
+        "attributes": {
+            "type": "object",
+            "properties": {
+                "tid": {
+                    "type": "integer",
+                    "title": "Term ID",
+                    "description": "The term ID."
+                },
+                "uuid": {
+                    "type": "string",
+                    "title": "UUID",
+                    "maxLength": 128,
+                    "description": "The term UUID."
+                },
+                "langcode": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "title": "Language code"
+                        },
+                        "language": {
+                            "type": "language_reference",
+                            "title": "Language object",
+                            "description": "The referenced language"
+                        }
+                    },
+                    "required": [
+                        "value"
+                    ],
+                    "title": "Language",
+                    "description": "The term language code."
+                },
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "maxLength": 255
+                },
+                "description": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "title": "Text"
+                        },
+                        "format": {
+                            "type": "string",
+                            "title": "Text format"
+                        }
+                    },
+                    "required": [
+                        "value"
+                    ],
+                    "title": "Description"
+                },
+                "weight": {
+                    "type": "integer",
+                    "title": "Weight",
+                    "description": "The weight of this term in relation to other terms.",
+                    "default": 0
+                },
+                "changed": {
+                    "type": "number",
+                    "title": "Changed",
+                    "format": "utc-millisec",
+                    "description": "The time that the term was last edited."
+                },
+                "default_langcode": {
+                    "type": "boolean",
+                    "title": "Default translation",
+                    "description": "A flag indicating whether this is the default translation.",
+                    "default": true
+                }
+            },
+            "required": [
+                "tid",
+                "uuid",
+                "name"
+            ]
+        },
+        "relationships": {
+            "properties": {
+                "vid": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "id"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "title": "Referenced resource",
+                                    "enum": [
+                                        "taxonomy_vocabulary--taxonomy_vocabulary"
+                                    ]
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "title": "Resource ID",
+                                    "format": "uuid",
+                                    "maxLength": 128
+                                }
+                            }
+                        }
+                    },
+                    "title": "Resource Identifier"
+                },
+                "parent": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "type",
+                                    "id"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "title": "Referenced resource",
+                                        "enum": [
+                                            "taxonomy_term--taxonomy_term"
+                                        ]
+                                    },
+                                    "id": {
+                                        "type": "string",
+                                        "title": "Resource ID",
+                                        "format": "uuid",
+                                        "maxLength": 128
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Resource Identifier"
+                }
+            },
+            "type": "object"
+        }
+    }
+}

--- a/tests/expectations/taxonomy_term.hal_json.json
+++ b/tests/expectations/taxonomy_term.hal_json.json
@@ -1,0 +1,240 @@
+{
+    "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+    "id": "{base_url}\/schemata\/taxonomy_term?_format=schema_json&_describes=hal_json",
+    "type": "object",
+    "title": "taxonomy_term Schema",
+    "description": "Describes the payload for 'taxonomy_term' entities.",
+    "properties": {
+        "tid": {
+            "type": "array",
+            "title": "Term ID",
+            "description": "The term ID.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "uuid": {
+            "type": "array",
+            "title": "UUID",
+            "description": "The term UUID.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 128
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "langcode": {
+            "type": "array",
+            "title": "Language",
+            "description": "The term language code.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Language code"
+                    },
+                    "language": {
+                        "type": "language_reference",
+                        "title": "Language object",
+                        "description": "The referenced language"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "vid": {
+            "type": "object",
+            "title": "Taxonomy vocabulary",
+            "description": "The referenced entity"
+        },
+        "name": {
+            "type": "array",
+            "title": "Name",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "description": {
+            "type": "array",
+            "title": "Description",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text"
+                    },
+                    "format": {
+                        "type": "string",
+                        "title": "Text format"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "weight": {
+            "type": "array",
+            "title": "Weight",
+            "description": "The weight of this term in relation to other terms.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": 0
+                }
+            ],
+            "maxItems": 1
+        },
+        "parent": {
+            "type": "object",
+            "title": "Taxonomy term",
+            "description": "The referenced entity"
+        },
+        "changed": {
+            "type": "array",
+            "title": "Changed",
+            "description": "The time that the term was last edited.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "default_langcode": {
+            "type": "array",
+            "title": "Default translation",
+            "description": "A flag indicating whether this is the default translation.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        },
+        "_links": {
+            "title": "HAL Links",
+            "description": "Object of links with the rels as the keys",
+            "type": "object",
+            "properties": {
+                "self": {
+                    "$ref": "#\/definitions\/linkObject"
+                },
+                "type": {
+                    "$ref": "#\/definitions\/linkObject"
+                }
+            }
+        }
+    },
+    "required": [
+        "tid",
+        "uuid",
+        "name"
+    ],
+    "definitions": {
+        "linkArray": {
+            "title": "HAL Link Array",
+            "description": "An array of linkObjects of the same link relation",
+            "type": "array",
+            "items": {
+                "$ref": "#\/definitions\/linkObject"
+            }
+        },
+        "linkObject": {
+            "title": "HAL Link Object",
+            "description": "An object with link information.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "description": "Name of a resource, link, action, etc.",
+                    "type": "string"
+                },
+                "title": {
+                    "title": "Title",
+                    "description": "A title for a resource, link, action, etc.",
+                    "type": "string"
+                },
+                "href": {
+                    "title": "HREF",
+                    "description": "A hyperlink URL.",
+                    "type": "string",
+                    "format": "uri"
+                }
+            },
+            "required": [
+                "href"
+            ]
+        }
+    }
+}

--- a/tests/expectations/taxonomy_term.json.json
+++ b/tests/expectations/taxonomy_term.json.json
@@ -1,0 +1,215 @@
+{
+    "$schema": "http:\/\/json-schema.org\/draft-04\/schema#",
+    "id": "{base_url}\/schemata\/taxonomy_term?_format=schema_json&_describes=json",
+    "type": "object",
+    "title": "taxonomy_term Schema",
+    "description": "Describes the payload for 'taxonomy_term' entities.",
+    "properties": {
+        "tid": {
+            "type": "array",
+            "title": "Term ID",
+            "description": "The term ID.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "uuid": {
+            "type": "array",
+            "title": "UUID",
+            "description": "The term UUID.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 128
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "langcode": {
+            "type": "array",
+            "title": "Language",
+            "description": "The term language code.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Language code"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "vid": {
+            "type": "array",
+            "title": "Vocabulary",
+            "description": "The vocabulary to which the term is assigned.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "target_id": {
+                        "type": "string",
+                        "title": "Taxonomy vocabulary ID"
+                    }
+                },
+                "required": [
+                    "target_id"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "name": {
+            "type": "array",
+            "title": "Name",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text value",
+                        "maxLength": 255
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "minItems": 1,
+            "maxItems": 1
+        },
+        "description": {
+            "type": "array",
+            "title": "Description",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "title": "Text"
+                    },
+                    "format": {
+                        "type": "string",
+                        "title": "Text format"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "weight": {
+            "type": "array",
+            "title": "Weight",
+            "description": "The weight of this term in relation to other terms.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "title": "Integer value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": 0
+                }
+            ],
+            "maxItems": 1
+        },
+        "parent": {
+            "type": "array",
+            "title": "Term Parents",
+            "description": "The parents of this term.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "target_id": {
+                        "type": "integer",
+                        "title": "Taxonomy term ID"
+                    }
+                },
+                "required": [
+                    "target_id"
+                ],
+                "title": "Taxonomy term",
+                "description": "The referenced entity"
+            }
+        },
+        "changed": {
+            "type": "array",
+            "title": "Changed",
+            "description": "The time that the term was last edited.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "title": "Timestamp value",
+                        "format": "utc-millisec"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "maxItems": 1
+        },
+        "default_langcode": {
+            "type": "array",
+            "title": "Default translation",
+            "description": "A flag indicating whether this is the default translation.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "boolean",
+                        "title": "Boolean value"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "default": [
+                {
+                    "value": true
+                }
+            ],
+            "maxItems": 1
+        }
+    },
+    "required": [
+        "tid",
+        "uuid",
+        "vid",
+        "name"
+    ]
+}

--- a/tests/src/Functional/RequestTest.php
+++ b/tests/src/Functional/RequestTest.php
@@ -92,12 +92,8 @@ class RequestTest extends BrowserTestBase {
     $entity_type_manager = $this->container->get('entity_type.manager');
 
     foreach (['json', 'hal_json', 'api_json'] as $format) {
-
       foreach ($entity_type_manager->getDefinitions() as $entity_type_id => $entity_type) {
-        // @todo Check for all entity types https://www.drupal.org/node/2870904.
-        if (!$entity_type->getBundleEntityType()) {
-          $this->requestSchema($format, $entity_type_id);
-        }
+        $this->requestSchema($format, $entity_type_id);
         if ($bundle_type = $entity_type->getBundleEntityType()) {
           $bundles = $entity_type_manager->getStorage($bundle_type)->loadMultiple();
           foreach ($bundles as $bundle) {


### PR DESCRIPTION
Re-opening/clean up of https://github.com/phase2/schemata/pull/15
Thanks so much for this module.
I am working on the OpenAPI module. Currently it has some code I copied over from the previous version of this module but I would like to remove it and rely on this module.
[#2870393: Remove openapi_json_schema submodule and add dependency on Schemata module](https://www.drupal.org/node/2870393)
I can almost use this module expect that you can longer produce schema for just and entity type if the entity also supports bundles.

This is needed when creating the OpenAPI spec because the REST resources don't really point to specific bundle(unlike JSON API).

This patch will add a route for all entity types regardless of whether they also supports bundles.

I am attaching Open API JSON file produced with patch to this module.
If look at the definitions section of this json you will see a definition for node, node:article and node:page. This is possible with changes to this module.
