### PR TITLE
Issue #2772991: Test that generated schemas are valid json-schema v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: TEST_SUITE=PHP_CodeSniffer
     - php: 7.0
       env: TEST_SUITE=PHP_CodeSniffer
+    - php: 5.6
+      env: TEST_SUITE=8.4.x
 
 mysql:
   database: schemata

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ before_script:
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
 
+  # Add Schemata dependent libraries. They must be installed as part of Drupal for autoloading..
+  # This needs to be manually updated whenever composer.json is updated.
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev league/json-guard:^1.0 league/json-reference:^1.0 --working-dir=$DRUPAL_DIR || true
+
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: php
 sudo: false
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.0
+  - 5.6
 
 env:
+  - TEST_SUITE=PHP_CodeSniffer
   - TEST_SUITE=8.3.x
   - TEST_SUITE=8.4.x
-  - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
 matrix:
@@ -38,6 +38,7 @@ before_script:
   - MODULE_DIR=$(pwd)
 
   # Install Composer dependencies for Schemata.
+  # @todo not needed for phpunit tests.
   - composer install
 
   # Navigate out of module directory to prevent blown stack by recursive module

--- a/tests/src/Functional/SchemataBrowserTestBase.php
+++ b/tests/src/Functional/SchemataBrowserTestBase.php
@@ -23,6 +23,13 @@ class SchemataBrowserTestBase extends BrowserTestBase {
   protected $entityTypeManager;
 
   /**
+   * Schema Factory.
+   *
+   * @var \Drupal\schemata\SchemaFactory
+   */
+  protected $schemaFactory;
+
+  /**
    * Dereferenced Schema Static Cache.
    *
    * @var array
@@ -53,6 +60,7 @@ class SchemataBrowserTestBase extends BrowserTestBase {
   protected function setUp() {
     parent::setUp();
     $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $this->schemaFactory = $this->container->get('schemata.schema_factory');
 
     if (!NodeType::load('camelids')) {
       // Create a "Camelids" node type.
@@ -112,7 +120,7 @@ class SchemataBrowserTestBase extends BrowserTestBase {
    * @see http://json-reference.thephpleague.com/caching
    */
   protected function getDereferencedSchema($url) {
-    if (!empty($this->schemaCache[$url])) {
+    if (empty($this->schemaCache[$url])) {
       $dereferencer = Dereferencer::draft4();
       // By definition of the JSON Schema spec, schemas use this key to refer
       // to the schema to which they conform.

--- a/tests/src/Functional/SchemataBrowserTestBase.php
+++ b/tests/src/Functional/SchemataBrowserTestBase.php
@@ -145,7 +145,6 @@ class SchemataBrowserTestBase extends BrowserTestBase {
    */
   protected function getRawSchemaByOptions($format, $entity_type_id, $bundle_id = NULL) {
     $url = SchemaUrl::fromOptions('schema_json', $format, $entity_type_id, $bundle_id)->toString();
-    print $url;
     return $this->drupalGet($url);
   }
 

--- a/tests/src/Functional/SchemataBrowserTestBase.php
+++ b/tests/src/Functional/SchemataBrowserTestBase.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\schemata\Functional;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Sets up functional testing for Schemata.
+ */
+class SchemataBrowserTestBase extends BrowserTestBase {
+
+  /**
+   * Entity Type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'user',
+    'field',
+    'filter',
+    'text',
+    'node',
+    'taxonomy',
+    'serialization',
+    'hal',
+    'schemata',
+    'schemata_json_schema',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+
+    if (!NodeType::load('camelids')) {
+      // Create a "Camelids" node type.
+      NodeType::create([
+        'name' => 'Camelids',
+        'type' => 'camelids',
+      ])->save();
+    }
+
+    // Create a "Camelids" vocabulary.
+    $vocabulary = Vocabulary::create([
+      'name' => 'Camelids',
+      'vid' => 'camelids',
+    ]);
+    $vocabulary->save();
+
+    $entity_types = ['node', 'taxonomy_term'];
+    foreach ($entity_types as $entity_type) {
+      // Add access-protected field.
+      FieldStorageConfig::create([
+        'entity_type' => $entity_type,
+        'field_name' => 'field_test_' . $entity_type,
+        'type' => 'text',
+      ])
+        ->setCardinality(1)
+        ->save();
+      FieldConfig::create([
+        'entity_type' => $entity_type,
+        'field_name' => 'field_test_' . $entity_type,
+        'bundle' => 'camelids',
+      ])
+        ->setLabel('Test field')
+        ->setTranslatable(FALSE)
+        ->save();
+    }
+    $this->container->get('router.builder')->rebuild();
+    $this->drupalLogin($this->drupalCreateUser(['access schemata data models']));
+  }
+
+  /**
+   * Requests a Schema via HTTP.
+   *
+   * @param string $format
+   *   The described format.
+   * @param string $entity_type_id
+   *   Then entity type.
+   * @param string|null $bundle_name
+   *   The bundle name or NULL.
+   */
+  protected function requestSchema($format, $entity_type_id, $bundle_name = NULL) {
+    $options = [
+      'query' => [
+        '_format' => 'schema_json',
+        '_describes' => $format,
+      ],
+    ];
+    return $this->drupalGet("schemata/$entity_type_id/$bundle_name", $options);
+  }
+
+}

--- a/tests/src/Functional/ValidateSchemaTest.php
+++ b/tests/src/Functional/ValidateSchemaTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\Tests\schemata\Functional;
+
+use League\JsonReference\Dereferencer;
+use League\JsonGuard\Validator;
+
+/**
+ * Tests that generated JSON Schemas are valid as JSON Schema.
+ *
+ * Without this test, we do not know that the entire schema conforms to the
+ * rules that constrain the structure of schemas.
+ *
+ * @group Schemata
+ * @group SchemataJsonSchema
+ */
+class ValidateSchemaTest extends SchemataBrowserTestBase {
+
+  /**
+   * Test the generated schemas are valid JSON Schema.
+   */
+  public function testSchemataAreValidJsonSchema() {
+    foreach (['json', 'hal_json', 'api_json'] as $described_format) {
+      foreach ($this->entityTypeManager->getDefinitions() as $entity_type_id => $entity_type) {
+        $this->validateSchemaAsJsonSchema($described_format, $entity_type_id);
+        if ($bundle_type = $entity_type->getBundleEntityType()) {
+          $bundles = $entity_type_manager->getStorage($bundle_type)->loadMultiple();
+          foreach ($bundles as $bundle) {
+            $this->validateSchemaAsJsonSchema($described_format, $entity_type_id, $bundle->id());
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Confirm a schema is inherently valid as a JSON Schema.
+   *
+   * @param string $format
+   *   The described format.
+   * @param string $entity_type_id
+   *   Then entity type.
+   * @param string|null $bundle_id
+   *   The bundle name or NULL.
+   */
+  protected function validateSchemaAsJsonSchema($format, $entity_type_id, $bundle_id = NULL) {
+    $json = $this->requestSchema($format, $entity_type_id, $bundle_id);
+    $this->assertSession()->statusCodeEquals(200);
+
+    try {
+      $data = json_decode($json);
+    }
+    catch (Exception $e) {
+      $this->assertTrue(FALSE, "Could not decode JSON from schema response. Error: " . $e->getMessage());
+    }
+
+    $dereferencer = Dereferencer::draft4();
+    // By definition of the JSON Schema spec, schemas use this key to refer
+    // to the schema to which they conform.
+    $schema = $dereferencer->dereference($data->{'$schema'});
+
+    $validator = new Validator($data, $schema);
+    if ($validator->fails()) {
+      $bundle_label = empty($bundle_id) ? 'no-bundle' : $bundle_id;
+      $message = "Schema ($entity_type_id:$bundle_label) failed validation for $format:\n";
+      $errors = $validator->errors();
+      foreach ($errors as $error) {
+        $message .= $error->getMessage() . "\n";
+      }
+      $this->assertTrue(FALSE, $message);
+    }
+
+    // Now that the schema has validated correctly, let's confirm an invalid
+    // schema will fail validation.
+    $data->properties = '';
+    $validator = new Validator($data, $schema);
+    if (!$validator->fails()) {
+      $bundle_label = empty($bundle_id) ? 'no-bundle' : $bundle_id;
+      $message = "Schema ($entity_type_id:$bundle_label) should fail validation if it is wrong.\n";
+      $this->assertTrue(FALSE, $message);
+    }
+  }
+
+}

--- a/tests/src/Functional/ValidateSchemaTest.php
+++ b/tests/src/Functional/ValidateSchemaTest.php
@@ -19,7 +19,7 @@ class ValidateSchemaTest extends SchemataBrowserTestBase {
    * Test the generated schemas are valid JSON Schema.
    */
   public function testSchemataAreValidJsonSchema() {
-    foreach (['json', 'hal_json', 'api_json'] as $described_format) {
+    foreach (['json', 'hal_json'] as $described_format) {
       foreach ($this->entityTypeManager->getDefinitions() as $entity_type_id => $entity_type) {
         try {
           // Retrieving the plugin is redundant, but if this succeeds without

--- a/tests/src/Functional/ValidateSchemaTest.php
+++ b/tests/src/Functional/ValidateSchemaTest.php
@@ -41,11 +41,13 @@ class ValidateSchemaTest extends SchemataBrowserTestBase {
    *   Then entity type.
    * @param string|null $bundle_id
    *   The bundle name or NULL.
+   *
+   * @todo how do you handle tests that should stop processing on a failure.
    */
   protected function validateSchemaAsJsonSchema($format, $entity_type_id, $bundle_id = NULL) {
     $json = $this->getRawSchemaByOptions($format, $entity_type_id, $bundle_id);
-    print_r($json);
     $this->assertSession()->statusCodeEquals(200);
+    $this->assertTrue(!empty($schema), 'Schema request should provide response content instead of a NULL value.');
 
     try {
       $data = json_decode($json);
@@ -53,6 +55,7 @@ class ValidateSchemaTest extends SchemataBrowserTestBase {
     catch (Exception $e) {
       $this->assertTrue(FALSE, "Could not decode JSON from schema response. Error: " . $e->getMessage());
     }
+    $this->assertNotEmpty($data->{'$schema'}, 'JSON Schema should include a $schema reference to a defining schema.');
 
     // Prepare the schema for validation.
     // By definition of the JSON Schema spec, schemas use a top-level '$schema'

--- a/tests/src/Kernel/SchemaFactoryTest.php
+++ b/tests/src/Kernel/SchemaFactoryTest.php
@@ -99,19 +99,35 @@ class SchemaFactoryTest extends KernelTestBase {
   /**
    * @covers ::create
    */
-  public function testInvalidEntity() {
-    $schema = $this->factory->create('camelid');
+  public function testInvalidEntityOnCreate() {
+    $schema = $this->factory->create('gastropod');
     $this->assertEmpty($schema, 'Schemata should not produce a schema for non-existant entity types.');
-    $schema = $this->factory->create('node', 'camelid');
+    $schema = $this->factory->create('node', 'gastropod');
     $this->assertEmpty($schema, 'Schemata should not produce a schema for non-existant bundles.');
+  }
+
+  /**
+   * @covers ::getSourceEntityPlugin
+   */
+  public function testInvalidEntityOnGetPlugin() {
+    $this->setExpectedException('\Drupal\Component\Plugin\Exception\PluginNotFoundException');
+    $this->factory->getSourceEntityPlugin('gastropod');
   }
 
   /**
    * @covers ::create
    */
-  public function testConfigEntity() {
+  public function testConfigEntityOnCreate() {
     $schema = $this->factory->create('node_type');
     $this->assertEmpty($schema, 'Schemata does not support Config entities.');
+  }
+
+  /**
+   * @covers ::getSourceEntityPlugin
+   */
+  public function testConfigEntityOnGetPlugin() {
+    $this->setExpectedException('\InvalidArgumentException');
+    $this->factory->getSourceEntityPlugin('node_type');
   }
 
   /**


### PR DESCRIPTION
* [x] The use of devDependenecies per https://www.drupal.org/node/2912265 is not working.
* [x] Should static cache the dereferenced schemas to minimize HTTP request & dereference actions. We especially do not need to retrieve and process the JSON Schema spec each time.