### PR TITLE
Issue #2914963: Schema Type Manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # CONTRIBUTING
 
+## Updating Development Dependencies
+
+In order to facilitate automated testing validation of the generated JSON Schema,
+we are adding league/json-guard and league/json-reference to Drupal's dependencies
+as part of the testing script.
+
+If the versions of these libraries are changed either in .travis.yml or in composer.json,
+it must be changed in the other.
+
 ## Add a New Schema Type Format
 
 Before submitting a change for a new Schema Type, [create an issue](https://www.drupal.org/project/issues/schemata)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# CONTRIBUTING
+
+## Add a New Schema Type Format
+
+Before submitting a change for a new Schema Type, [create an issue](https://www.drupal.org/project/issues/schemata)
+to discuss the new format. In most cases you will be asked to create this as a
+separate project dependent on Schemata, but this issue will also serve for
+preliminary guidance and early notice for a new project link from the Schemata
+Project page and README.
+
+### Technical Steps
+
+To add a new Schema Type format, you will take the following steps:
+
+* Create a set of Normalizers that can process a SchemaInterface.
+* Create a SchemaType plugin that declares your Schema Type and what formats it supports.
+* Implement Drupal\Core\DependencyInjection\ServiceModifierInterface to
+  associate a MIME Type with your Schema Type. In the future this may be done
+  automatically by Schemata by adding a MIME Type key to the SchemaType plugin.

--- a/schemata.services.yml
+++ b/schemata.services.yml
@@ -17,6 +17,19 @@ services:
       - '@typed_data_manager'
       - '@config.typed'
 
+  plugin.manager.schemata.schema_type:
+    class: Drupal\schemata\Plugin\Type\SchemaTypePluginManager
+    arguments:
+      - '@container.namespaces'
+      - '@cache.discovery'
+      - '@module_handler'
+
+  schemata.type_manager:
+    class: Drupal\schemata\SchemaTypeManager
+    arguments:
+      - '@plugin.manager.schemata.schema_type'
+      - '%serializer.formats%'
+
   # Create a log channel for this module. This simplifies logging setup code in
   # this code that will do logging. As a tradeoff, it also adds this fairly
   # specific logging channel to the system for all requests.

--- a/schemata_json_schema/schemata_json_schema.module
+++ b/schemata_json_schema/schemata_json_schema.module
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * Module code for Schemata JSON Schema module.
+ */
+
+/**
+ * Implements hook_schemata_schema_type_alter().
+ */
+function schemata_json_schema_schemata_schema_type_alter(&$definitions) {
+  if (\Drupal::moduleHandler()->moduleExists('hal')) {
+    $definitions['schema_json']['describes']['hal_json'] = 'HAL+JSON';
+  }
+  if (\Drupal::moduleHandler()->moduleExists('jsonapi')) {
+    $definitions['schema_json']['describes']['api_json'] = 'JSONAPI';
+  }
+}

--- a/schemata_json_schema/src/Plugin/schemata/schema_type/JsonSchema.php
+++ b/schemata_json_schema/src/Plugin/schemata/schema_type/JsonSchema.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\schemata_json_schema\Plugin\schemata\schema_type;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\schemata\Plugin\SchemaTypeInterface;
+
+/**
+ * Describe JSON Schema as a supported Schema Type.
+ *
+ * @SchemaType(
+ *   id = "schema_json",
+ *   label = @Translation("JSON Schema v4"),
+ *   documentation_url = "http://json-schema.org",
+ *   describes = {
+ *     "json" = "JSON"
+ *   }
+ * )
+ */
+class JsonSchema extends PluginBase implements SchemaTypeInterface {
+
+}

--- a/src/Annotation/SchemaType.php
+++ b/src/Annotation/SchemaType.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\schemata\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Schemata Schema Type annotation object.
+ *
+ * Plugin Namespace: Plugin\schemata\schema_type
+ *
+ * For a working example, see \Drupal\schemata_json_schema\Plugin\schemata\schema_type\JsonSchema
+ *
+ * @see \Drupal\schemata\Plugin\Type\SchemaTypePluginManager
+ * @see \Drupal\schemata\Plugin\SchemaTypeInterface
+ * @see plugin_api
+ *
+ * @ingroup third_party
+ *
+ * @Annotation
+ */
+class SchemaType extends Plugin {
+
+  /**
+   * The Schema Type plugin ID.
+   *
+   * Must match the identifier expected by the related normalizers in the
+   * _format querystring.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the Schema Type plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $label;
+
+  /**
+   * URL to the documentation of this schema type.
+   *
+   * Use of this is not yet implemented.
+   *
+   * @var string (optional)
+   */
+  public $documentation_url;
+
+  /**
+   * List of serialization formats this schema type currently supports.
+   *
+   * Must match the identifier expected by the related normalizers in the
+   * _describes querystring.
+   *
+   * @var string[]
+   */
+  public $describes;
+
+}

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -7,10 +7,8 @@ use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\schemata\SchemaFactory;
-use Drupal\schemata\SchemaTypeManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -33,13 +31,6 @@ class Controller extends ControllerBase {
   protected $schemaFactory;
 
   /**
-   * SchemaTypeManager.
-   *
-   * @var \Drupal\schemata\SchemaTypeManager
-   */
-  protected $typeManager;
-
-  /**
    * The cacheable response.
    *
    * @var \Drupal\Core\Cache\CacheableResponseInterface
@@ -53,15 +44,12 @@ class Controller extends ControllerBase {
    *   The serializer service.
    * @param \Drupal\schemata\SchemaFactory $schema_factory
    *   The schema factory.
-   * @param \Drupal\schemata\SchemaTypeManager $type_manager
-   *   SchemaTypeManager.
    * @param \Drupal\Core\Cache\CacheableResponseInterface $response
    *   The cacheable response.
    */
-  public function __construct(SerializerInterface $serializer, SchemaFactory $schema_factory, SchemaTypeManager $type_manager, CacheableResponseInterface $response) {
+  public function __construct(SerializerInterface $serializer, SchemaFactory $schema_factory, CacheableResponseInterface $response) {
     $this->serializer = $serializer;
     $this->schemaFactory = $schema_factory;
-    $this->typeManager = $type_manager;
     $this->response = $response;
   }
 
@@ -72,7 +60,6 @@ class Controller extends ControllerBase {
     return new static(
       $container->get('serializer'),
       $container->get('schemata.schema_factory'),
-      $container->get('schemata.type_manager'),
       new CacheableResponse()
     );
   }
@@ -94,65 +81,16 @@ class Controller extends ControllerBase {
    *
    * @return \Drupal\Core\Cache\CacheableResponse
    *   The response object.
-   *
-   * @todo Handle an empty _format query parameter. https://www.drupal.org/node/2773009
-   * @todo Handle an empty _describes query parameter. https://www.drupal.org/node/2910018
-   * @todo Handle MIME type not associated with the given schema type.
    */
   public function serialize($entity_type_id, Request $request, $bundle = NULL) {
-    list ($schema_type, $described_format) = $this->extractFormatNames($request);
+    $parts = $this->extractFormatNames($request);
 
-    // Load the schema data to serialize from the request route information.
-    /** @var \Drupal\schemata\Schema\SchemaInterface $schema */
+    // Load the data to serialize from the route information on the current
+    // request.
     $schema = $this->schemaFactory->create($entity_type_id, $bundle);
-    $format = "{$schema_type}:{$described_format}";
-    $mime_type = $request->getMimeType($schema_type);
-
-    try {
-      if (!$this->typeManager->schemaTypeExists($schema_type)) {
-        $error = [
-          'title' => t('Unrecognized Schema Type'),
-          'details' => t('Your requested schema type format @type is not supported.', [
-            '@type' => $schema_type
-          ]),
-          'status' => 400,
-          'instance' => "#{$schema_type}",
-        ];
-        $mime_type = 'application/problem+json';
-        $content = $this->serializer->serialize($error, 'json');
-        $this->response->setStatusCode($error['status']);
-      }
-      elseif (!$this->typeManager->schemaTypeSupportsFormat($schema_type, $described_format)) {
-        $error = [
-          'title' => t('Unrecognized Format for Schema Description'),
-          'details' => t('The format you requested to be described by @type is not available for @described.', [
-            '@type' => $schema_type,
-            '@described' => $described_format,
-          ]),
-          'status' => 400,
-          'instance' => "#{$schema_type}-{$described_format}",
-        ];
-        $mime_type = 'application/problem+json';
-        $content = $this->serializer->serialize($error, 'json');
-        $this->response->setStatusCode($error['status']);
-      }
-      else {
-        // Serialize the entity type/bundle definition.
-        $content = $this->serializer->serialize($schema, $format);
-      }
-    }
-    catch(\Exception $e) {
-      $error = [
-        'title' => t('Error Assembling Schema'),
-        'details' => t('Something went wrong building your schema after collecting the data and during the process of arrranging it for your selected schema format.'),
-        'status' => 500,
-        // @todo Log this error instead of returning it in the message.
-        'error' => $e->getMessage(),
-      ];
-      $mime_type = 'application/problem+json';
-      $content = $this->serializer->serialize($error, 'json');
-      $this->response->setStatusCode($error['status']);
-    }
+    // Serialize the entity type/bundle definition.
+    $format = implode(':', $parts);
+    $content = $this->serializer->serialize($schema, $format);
 
     // Finally, set the contents of the response and return it.
     $this->response->addCacheableDependency($schema);
@@ -160,8 +98,7 @@ class Controller extends ControllerBase {
       ->addCacheContexts(['url.query_args:_describes']);
     $this->response->addCacheableDependency($cacheable_dependency);
     $this->response->setContent($content);
-    $this->response->headers->set('Content-Type', $mime_type);
-
+    $this->response->headers->set('Content-Type', $request->getMimeType($parts[0]));
     return $this->response;
   }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -7,8 +7,10 @@ use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\schemata\SchemaFactory;
+use Drupal\schemata\SchemaTypeManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -31,6 +33,13 @@ class Controller extends ControllerBase {
   protected $schemaFactory;
 
   /**
+   * SchemaTypeManager.
+   *
+   * @var \Drupal\schemata\SchemaTypeManager
+   */
+  protected $typeManager;
+
+  /**
    * The cacheable response.
    *
    * @var \Drupal\Core\Cache\CacheableResponseInterface
@@ -44,12 +53,15 @@ class Controller extends ControllerBase {
    *   The serializer service.
    * @param \Drupal\schemata\SchemaFactory $schema_factory
    *   The schema factory.
+   * @param \Drupal\schemata\SchemaTypeManager $type_manager
+   *   SchemaTypeManager.
    * @param \Drupal\Core\Cache\CacheableResponseInterface $response
    *   The cacheable response.
    */
-  public function __construct(SerializerInterface $serializer, SchemaFactory $schema_factory, CacheableResponseInterface $response) {
+  public function __construct(SerializerInterface $serializer, SchemaFactory $schema_factory, SchemaTypeManager $type_manager, CacheableResponseInterface $response) {
     $this->serializer = $serializer;
     $this->schemaFactory = $schema_factory;
+    $this->typeManager = $type_manager;
     $this->response = $response;
   }
 
@@ -60,6 +72,7 @@ class Controller extends ControllerBase {
     return new static(
       $container->get('serializer'),
       $container->get('schemata.schema_factory'),
+      $container->get('schemata.type_manager'),
       new CacheableResponse()
     );
   }
@@ -81,16 +94,65 @@ class Controller extends ControllerBase {
    *
    * @return \Drupal\Core\Cache\CacheableResponse
    *   The response object.
+   *
+   * @todo Handle an empty _format query parameter. https://www.drupal.org/node/2773009
+   * @todo Handle an empty _describes query parameter. https://www.drupal.org/node/2910018
+   * @todo Handle MIME type not associated with the given schema type.
    */
   public function serialize($entity_type_id, Request $request, $bundle = NULL) {
-    $parts = $this->extractFormatNames($request);
+    list ($schema_type, $described_format) = $this->extractFormatNames($request);
 
-    // Load the data to serialize from the route information on the current
-    // request.
+    // Load the schema data to serialize from the request route information.
+    /** @var \Drupal\schemata\Schema\SchemaInterface $schema */
     $schema = $this->schemaFactory->create($entity_type_id, $bundle);
-    // Serialize the entity type/bundle definition.
-    $format = implode(':', $parts);
-    $content = $this->serializer->serialize($schema, $format);
+    $format = "{$schema_type}:{$described_format}";
+    $mime_type = $request->getMimeType($schema_type);
+
+    try {
+      if (!$this->typeManager->schemaTypeExists($schema_type)) {
+        $error = [
+          'title' => t('Unrecognized Schema Type'),
+          'details' => t('Your requested schema type format @type is not supported.', [
+            '@type' => $schema_type
+          ]),
+          'status' => 400,
+          'instance' => "#{$schema_type}",
+        ];
+        $mime_type = 'application/problem+json';
+        $content = $this->serializer->serialize($error, 'json');
+        $this->response->setStatusCode($error['status']);
+      }
+      elseif (!$this->typeManager->schemaTypeSupportsFormat($schema_type, $described_format)) {
+        $error = [
+          'title' => t('Unrecognized Format for Schema Description'),
+          'details' => t('The format you requested to be described by @type is not available for @described.', [
+            '@type' => $schema_type,
+            '@described' => $described_format,
+          ]),
+          'status' => 400,
+          'instance' => "#{$schema_type}-{$described_format}",
+        ];
+        $mime_type = 'application/problem+json';
+        $content = $this->serializer->serialize($error, 'json');
+        $this->response->setStatusCode($error['status']);
+      }
+      else {
+        // Serialize the entity type/bundle definition.
+        $content = $this->serializer->serialize($schema, $format);
+      }
+    }
+    catch(\Exception $e) {
+      $error = [
+        'title' => t('Error Assembling Schema'),
+        'details' => t('Something went wrong building your schema after collecting the data and during the process of arrranging it for your selected schema format.'),
+        'status' => 500,
+        // @todo Log this error instead of returning it in the message.
+        'error' => $e->getMessage(),
+      ];
+      $mime_type = 'application/problem+json';
+      $content = $this->serializer->serialize($error, 'json');
+      $this->response->setStatusCode($error['status']);
+    }
 
     // Finally, set the contents of the response and return it.
     $this->response->addCacheableDependency($schema);
@@ -98,7 +160,8 @@ class Controller extends ControllerBase {
       ->addCacheContexts(['url.query_args:_describes']);
     $this->response->addCacheableDependency($cacheable_dependency);
     $this->response->setContent($content);
-    $this->response->headers->set('Content-Type', $request->getMimeType($parts[0]));
+    $this->response->headers->set('Content-Type', $mime_type);
+
     return $this->response;
   }
 

--- a/src/Plugin/SchemaTypeInterface.php
+++ b/src/Plugin/SchemaTypeInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\schemata\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Describes a supported Schema Type.
+ *
+ * @see \Drupal\schemata\Annotation\SchemaType
+ * @see \Drupal\schemata\Plugin\Type\SchemaTypePluginManager
+ * @see plugin_api
+ *
+ * @ingroup third_party
+ */
+interface SchemaTypeInterface extends PluginInspectionInterface {
+
+}

--- a/src/Plugin/Type/SchemaTypePluginManager.php
+++ b/src/Plugin/Type/SchemaTypePluginManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\schemata\Plugin\Type;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Manages SchemaType plugins.
+ *
+ * SchemaType provides metadata about a schemata schema format.
+ * Formats are otherwise only defined by the collection of normalizers that
+ * are invoked for actual use.
+ *
+ * @see \Drupal\schemata\Annotation\SchemaType
+ * @see \Drupal\schemata\Plugin\schemata\SchemaTypePluginBase
+ * @see \Drupal\schemata\Plugin\schemata\\SchemaTypeInterface
+ * @see plugin_api
+ */
+class SchemaTypePluginManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new SchemaTypePluginManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/schemata/schema_type', $namespaces, $module_handler, 'Drupal\schemata\Plugin\SchemaTypeInterface', 'Drupal\schemata\Annotation\SchemaType');
+
+    $this->setCacheBackend($cache_backend, 'schemata_schema_type_plugins');
+    $this->alterInfo('schemata_schema_type');
+  }
+}

--- a/src/SchemaTypeManager.php
+++ b/src/SchemaTypeManager.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\schemata;
+
+use Drupal\schemata\Plugin\Type\SchemaTypePluginManager;
+
+/**
+ * Manage available Schema Formats.
+ */
+class SchemaTypeManager {
+
+  /**
+   * SchemaTypePluginManager.
+   *
+   * @var \Drupal\schemata\Plugin\Type\SchemaTypePluginManager
+   */
+  protected $pluginManager;
+
+  /**
+   * The available serialization formats.
+   *
+   * @var array
+   */
+  protected $serializerFormats = [];
+
+  /**
+   * SchemaFormatHelper constructor.
+   *
+   * @param \Drupal\schemata\Plugin\Type\SchemaTypePluginManager $plugin_manager
+   *   SchemaTypePluginManager.
+   * @param array $serializer_formats
+   *   The available serializer formats.
+   */
+  public function __construct(SchemaTypePluginManager $plugin_manager, array $serializer_formats = []) {
+    $this->pluginManager = $plugin_manager;
+    $this->serializerFormats = $serializer_formats;
+  }
+
+  /**
+   * Retrieve a list of the unsupported Schema Types.
+   *
+   * This is primarily used for error reporting.
+   *
+   * @see schemata_requirements().
+   *
+   * @return \Drupal\schemata\Plugin\Type\SchemaTypeInterface[]
+   *  Each plugin definition is keyed on its ID.
+   */
+  public function getUnsupportedTypeList() {
+    $plugins = $this->pluginManager->getDefinitions();
+    $plugins = array_filter($plugins, function($plugin) {
+      return !$this->isSerializationFormat($plugin['id']);
+    });
+
+    return $plugins;
+  }
+
+  /**
+   * Retrieve a list of supported Schema Types.
+   *
+   * "Supported" in this case means there are identified normalizers for the
+   * defined type.
+   *
+   * @return \Drupal\schemata\Plugin\Type\SchemaTypeInterface[]
+   *  Each plugin definition is keyed on its ID.
+   */
+  public function getSupportedTypeList() {
+    $plugins = $this->pluginManager->getDefinitions();
+    $plugins = array_filter($plugins, function($plugin) {
+      return $this->isSerializationFormat($plugin['id']);
+    });
+
+    return $plugins;
+  }
+
+  /**
+   * Checks if a given type exists, with the implication it is supported.
+   *
+   * @param string $name
+   *   Name of a Schema Type.
+   *
+   * @return bool
+   *   TRUE if the Schema Type is available, FALSE otherwise.
+   */
+  public function schemaTypeExists($name) {
+    return array_key_exists($name, $this->getSupportedTypeList());
+  }
+
+  /**
+   * Identify if the named plugin supports the described serialization format.
+   *
+   * @param string $name
+   *   Name of a Schema Type.
+   * @param string $described_format
+   *   Name of a serialization format.
+   *
+   * @return bool
+   *   TRUE if the schema type exists and can support the named format.
+   */
+  public function schemaTypeSupportsFormat($name, $described_format) {
+    return $this->schemaTypeExists($name) &&
+      array_key_exists($described_format, $this->pluginManager->getDefinition($name)['describes']);
+  }
+
+  /**
+   * Checks if a given type is a supported serialization format.
+   *
+   * @param string $name
+   *   Name of a serializer format.
+   *
+   * @return bool
+   *   TRUE if the serialize format is available, FALSE otherwise.
+   */
+  public function isSerializationFormat($name) {
+    return array_key_exists($name, array_flip($this->serializerFormats));
+  }
+
+}

--- a/tests/src/Functional/ValidateSchemaTest.php
+++ b/tests/src/Functional/ValidateSchemaTest.php
@@ -65,7 +65,7 @@ class ValidateSchemaTest extends SchemataBrowserTestBase {
     try {
       $data = json_decode($json);
     }
-    catch (Exception $e) {
+    catch (\Exception $e) {
       $this->assertTrue(FALSE, "Could not decode JSON from schema response. Error: " . $e->getMessage());
     }
     $this->assertNotEmpty($data->{'$schema'}, 'JSON Schema should include a $schema reference to a defining schema.');

--- a/tests/src/Kernel/SchemaTypeTest.php
+++ b/tests/src/Kernel/SchemaTypeTest.php
@@ -78,8 +78,8 @@ class SchemaTypeTest extends KernelTestBase {
     $this->assertTrue($this->typeManager->schemaTypeSupportsFormat('schema_json', 'json'),
       '"schema_json" can be used to describe "json"');
     // Are we properly adjusting to the HAL module being enabled?
-    $this->assertTrue($this->typeManager->schemaTypeSupportsFormat('schema_json', 'hsl'),
-      '"schema_json" can be used to describe "hal"');
+    $this->assertTrue($this->typeManager->schemaTypeSupportsFormat('schema_json', 'hal_json'),
+      '"schema_json" can be used to describe "hal_json"');
     // Handles the case of a format that is never expected.
     $this->assertFalse($this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
       '"schema_json" cannot describe invalid format "camelid"');
@@ -90,7 +90,7 @@ class SchemaTypeTest extends KernelTestBase {
     $this->assertFalse($this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
       '"schema_json" cannot describe inactive format "api_json"');
     $this->assertFalse($this->typeManager->schemaTypeSupportsFormat('camelid', 'json'),
-      'invalid serializer "camelid" cannot describe format "json"');
+      'invalid serialization format "camelid" cannot describe format "json"');
   }
 
   /**

--- a/tests/src/Kernel/SchemaTypeTest.php
+++ b/tests/src/Kernel/SchemaTypeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\Tests\schemata\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\schemata\Schema\SchemaTypeManager;
+
+/**
+ * Tests the Schema Type Manager service.
+ *
+ * @coversDefaultClass \Drupal\schemata\SchemaTypeManager
+ * @group Schemata
+ * @group SchemataCore
+ */
+class SchemaTypeTest extends KernelTestBase {
+
+  /**
+   * Schema Type Manager.
+   *
+   * @var \Drupal\schemata\SchemaTypeManager
+   */
+  protected $typeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'hal',
+    'schemata_json_schema',
+    'serialization',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->typeManager = \Drupal::service('schemata.type_manager');
+  }
+
+  /**
+   * @todo Add a SchemaType without a matching serializer to test this.
+   * @covers ::getUnsupportedTypeList
+   */
+  public function testUnsupportedTypeList() {
+  }
+
+  /**
+   * @covers ::getSupportedTypeList
+   */
+  public function testSupportedTypeList() {
+    assertEquals(
+      ['schema_json'],
+      array_keys($this->typeManager->getSupportedTypeList()),
+      'The list of schema types is correct'
+    );
+  }
+
+  /**
+   * @covers ::schemaTypeExists
+   */
+  public function testSchemaTypeExists() {
+    assert($this->typeManager->schemaTypeExists('schema_json'),
+      '"schema_json" schema type is defined and ready for use');
+    assert($this->typeManager->schemaTypeExists('camelid'),
+      'invalid "camelid" schema type does not exist');
+  }
+
+  /**
+   * @covers ::schemaTypeSupportsFormat
+   */
+  public function testSchemaTypeSupportsFormat() {
+    // Can we support our default base case?
+    assert($this->typeManager->schemaTypeSupportsFormat('schema_json', 'json'),
+      '"schema_json" can be used to describe "json"');
+    // Are we properly adjusting to the HAL module being enabled?
+    assert($this->typeManager->schemaTypeSupportsFormat('schema_json', 'hsl'),
+      '"schema_json" can be used to describe "hal"');
+    // Handles the case of a format that is never expected.
+    assert(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
+      '"schema_json" cannot describe invalid format "camelid"');
+    // Handles the case of a format we are not currently enabled, but we might
+    // add support for in the future. api_json and camelid together help triangulate
+    // which type of error we might run into at that time.
+    assert(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
+      '"schema_json" cannot describe inactive format "api_json"');
+    assert(!$this->typeManager->schemaTypeSupportsFormat('camelid', 'json'),
+      'invalid serializer "camelid" cannot describe format "json"');
+  }
+
+  /**
+   * @covers ::isSerializationFormat
+   */
+  public function isSerializationFormat() {
+    assert($this->typeManager->isSerializationFormat('json'),
+      '"json" is identified as a format.');
+    assert(!$this->typeManager->isSerializationFormat('camelid'),
+      '"camelid" is an invalid serializer format.');
+  }
+}

--- a/tests/src/Kernel/SchemaTypeTest.php
+++ b/tests/src/Kernel/SchemaTypeTest.php
@@ -25,6 +25,7 @@ class SchemaTypeTest extends KernelTestBase {
    */
   public static $modules = [
     'hal',
+    'schemata',
     'schemata_json_schema',
     'serialization',
     'system',
@@ -36,7 +37,6 @@ class SchemaTypeTest extends KernelTestBase {
    */
   protected function setUp() {
     parent::setUp();
-
     $this->typeManager = \Drupal::service('schemata.type_manager');
   }
 

--- a/tests/src/Kernel/SchemaTypeTest.php
+++ b/tests/src/Kernel/SchemaTypeTest.php
@@ -53,7 +53,7 @@ class SchemaTypeTest extends KernelTestBase {
    * @covers ::getSupportedTypeList
    */
   public function testSupportedTypeList() {
-    assertEquals(
+    $this->assertEquals(
       ['schema_json'],
       array_keys($this->typeManager->getSupportedTypeList()),
       'The list of schema types is correct'
@@ -64,7 +64,7 @@ class SchemaTypeTest extends KernelTestBase {
    * @covers ::schemaTypeExists
    */
   public function testSchemaTypeExists() {
-    assert($this->typeManager->schemaTypeExists('schema_json'),
+    $this->assertTrue($this->typeManager->schemaTypeExists('schema_json'),
       '"schema_json" schema type is defined and ready for use');
     assert($this->typeManager->schemaTypeExists('camelid'),
       'invalid "camelid" schema type does not exist');
@@ -75,21 +75,21 @@ class SchemaTypeTest extends KernelTestBase {
    */
   public function testSchemaTypeSupportsFormat() {
     // Can we support our default base case?
-    assert($this->typeManager->schemaTypeSupportsFormat('schema_json', 'json'),
+    $this->assertTrue($this->typeManager->schemaTypeSupportsFormat('schema_json', 'json'),
       '"schema_json" can be used to describe "json"');
     // Are we properly adjusting to the HAL module being enabled?
-    assert($this->typeManager->schemaTypeSupportsFormat('schema_json', 'hsl'),
+    $this->assertTrue($this->typeManager->schemaTypeSupportsFormat('schema_json', 'hsl'),
       '"schema_json" can be used to describe "hal"');
     // Handles the case of a format that is never expected.
-    assert(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
+    $this->assertTrue(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
       '"schema_json" cannot describe invalid format "camelid"');
     // Handles the case of a format not currently enabled, but we might add
     // support in the future. Both test cases are present to help catch
     // the problem if JSONAPI is added to this test in the future.
     // which type of error we might run into at that time.
-    assert(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
+    $this->assertTrue(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
       '"schema_json" cannot describe inactive format "api_json"');
-    assert(!$this->typeManager->schemaTypeSupportsFormat('camelid', 'json'),
+    $this->assertTrue(!$this->typeManager->schemaTypeSupportsFormat('camelid', 'json'),
       'invalid serializer "camelid" cannot describe format "json"');
   }
 
@@ -97,9 +97,9 @@ class SchemaTypeTest extends KernelTestBase {
    * @covers ::isSerializationFormat
    */
   public function isSerializationFormat() {
-    assert($this->typeManager->isSerializationFormat('json'),
+    $this->assertTrue($this->typeManager->isSerializationFormat('json'),
       '"json" is identified as a format.');
-    assert(!$this->typeManager->isSerializationFormat('camelid'),
+    $this->assertTrue(!$this->typeManager->isSerializationFormat('camelid'),
       '"camelid" is an invalid serializer format.');
   }
 

--- a/tests/src/Kernel/SchemaTypeTest.php
+++ b/tests/src/Kernel/SchemaTypeTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\schemata\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\schemata\Schema\SchemaTypeManager;
 
 /**
  * Tests the Schema Type Manager service.
@@ -42,6 +41,8 @@ class SchemaTypeTest extends KernelTestBase {
   }
 
   /**
+   * Test coverage for the Unsupported Type List.
+   *
    * @todo Add a SchemaType without a matching serializer to test this.
    * @covers ::getUnsupportedTypeList
    */
@@ -82,8 +83,9 @@ class SchemaTypeTest extends KernelTestBase {
     // Handles the case of a format that is never expected.
     assert(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
       '"schema_json" cannot describe invalid format "camelid"');
-    // Handles the case of a format we are not currently enabled, but we might
-    // add support for in the future. api_json and camelid together help triangulate
+    // Handles the case of a format not currently enabled, but we might add
+    // support in the future. Both test cases are present to help catch
+    // the problem if JSONAPI is added to this test in the future.
     // which type of error we might run into at that time.
     assert(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
       '"schema_json" cannot describe inactive format "api_json"');
@@ -100,4 +102,5 @@ class SchemaTypeTest extends KernelTestBase {
     assert(!$this->typeManager->isSerializationFormat('camelid'),
       '"camelid" is an invalid serializer format.');
   }
+
 }

--- a/tests/src/Kernel/SchemaTypeTest.php
+++ b/tests/src/Kernel/SchemaTypeTest.php
@@ -66,7 +66,7 @@ class SchemaTypeTest extends KernelTestBase {
   public function testSchemaTypeExists() {
     $this->assertTrue($this->typeManager->schemaTypeExists('schema_json'),
       '"schema_json" schema type is defined and ready for use');
-    assert($this->typeManager->schemaTypeExists('camelid'),
+    $this->assertFalse($this->typeManager->schemaTypeExists('camelid'),
       'invalid "camelid" schema type does not exist');
   }
 
@@ -81,15 +81,15 @@ class SchemaTypeTest extends KernelTestBase {
     $this->assertTrue($this->typeManager->schemaTypeSupportsFormat('schema_json', 'hsl'),
       '"schema_json" can be used to describe "hal"');
     // Handles the case of a format that is never expected.
-    $this->assertTrue(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
+    $this->assertFalse($this->typeManager->schemaTypeSupportsFormat('schema_json', 'camelid'),
       '"schema_json" cannot describe invalid format "camelid"');
     // Handles the case of a format not currently enabled, but we might add
     // support in the future. Both test cases are present to help catch
     // the problem if JSONAPI is added to this test in the future.
     // which type of error we might run into at that time.
-    $this->assertTrue(!$this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
+    $this->assertFalse($this->typeManager->schemaTypeSupportsFormat('schema_json', 'api_json'),
       '"schema_json" cannot describe inactive format "api_json"');
-    $this->assertTrue(!$this->typeManager->schemaTypeSupportsFormat('camelid', 'json'),
+    $this->assertFalse($this->typeManager->schemaTypeSupportsFormat('camelid', 'json'),
       'invalid serializer "camelid" cannot describe format "json"');
   }
 
@@ -99,8 +99,8 @@ class SchemaTypeTest extends KernelTestBase {
   public function isSerializationFormat() {
     $this->assertTrue($this->typeManager->isSerializationFormat('json'),
       '"json" is identified as a format.');
-    $this->assertTrue(!$this->typeManager->isSerializationFormat('camelid'),
-      '"camelid" is an invalid serializer format.');
+    $this->assertFalse($this->typeManager->isSerializationFormat('camelid'),
+      '"camelid" is an invalid serializer format');
   }
 
 }


### PR DESCRIPTION
Fixes [d.o:#2914963](https://www.drupal.org/project/schemata/issues/2914963)

Adds a formal way to declare a schema type. Drupal serializers are a loose collection of services defined in a bottom up manner, this means it's very difficult to build explicit UI around knowing what formats we really have and support for a specialized subset of formats.

Not sure if the overhead of the plugin system is the right way to go, but it has advantages of learnability and extensibility